### PR TITLE
Add @RestrictTo annotation

### DIFF
--- a/core/src/main/kotlin/Java/JavaPsiDocumentationBuilder.kt
+++ b/core/src/main/kotlin/Java/JavaPsiDocumentationBuilder.kt
@@ -161,6 +161,7 @@ class JavaPsiDocumentationBuilder : JavaDocumentationBuilder {
             skipElementByVisibility(element) ||
                     hasSuppressDocTag(element) ||
                     hasHideAnnotation(element) ||
+                    hasRestrictToAnnotation(element) ||
                     skipElementBySuppressedFiles(element)
 
     private fun skipElementByVisibility(element: Any): Boolean =
@@ -343,9 +344,38 @@ fun hasSuppressDocTag(element: Any?): Boolean {
  *
  * @return true if @hide is present, otherwise false
  *
- * Note: this does not process @hide annotations in KDoc.  For KDoc, use the @suppress tag instead, which is processed
- * by [hasSuppressDocTag].
+ * This function is similar to [hasRestrictToAnnotation].
+ *
+ * Note: this does not process @hide annotations in KDoc.
+ * For KDoc, use the @suppress tag instead, which is processed by [hasSuppressDocTag].
  */
-fun hasHideAnnotation(element: Any?): Boolean {
-    return element is PsiDocCommentOwner && element.docComment?.run { findTagByName("hide") != null } ?: false
+fun hasHideAnnotation(element: Any?) = hasAHiddenNotation(element, "hide")
+
+/**
+ * Determines if the @RestrictTo annotation is present in a Javadoc comment.
+ *
+ * @param element a doc element to analyze for the presence of @RestrictTo
+ *
+ * @return true if @RestrictTo is present, otherwise false
+ *
+ * This function is similar to [hasHideAnnotation]
+ *
+ * Note: this does not process @RestrictTo annotations in KDoc.
+ * For KDoc, use the @suppress tag instead, which is processed by [hasSuppressDocTag].
+ */
+fun hasRestrictToAnnotation(element: Any?) = hasAHiddenNotation(element, "RestrictTo")
+
+/**
+ * This is a helper method for [hasHideAnnotation] and [hasRestrictToAnnotation]
+ *
+ * Determines if the given annotation is present in a Javadoc comment.
+ *
+ * @param element a doc element to analyze for the presence of [hideAnnotation]
+ * @param hideAnnotation the annotation to search for
+ *
+ * @return true if [hideAnnotation] is present, otherwise false
+ *
+ */
+private fun hasAHiddenNotation(element: Any?, hideAnnotation: String): Boolean {
+    return element is PsiDocCommentOwner && element.docComment?.run { findTagByName(hideAnnotation) != null } ?: false
 }

--- a/core/src/main/kotlin/Kotlin/DocumentationBuilder.kt
+++ b/core/src/main/kotlin/Kotlin/DocumentationBuilder.kt
@@ -1051,7 +1051,9 @@ fun DeclarationDescriptor.isDocumentationSuppressed(options: DocumentationOption
     val doc = findKDoc()
     if (doc is KDocSection && doc.findTagByName("suppress") != null) return true
 
-    return hasSuppressDocTag(sourcePsi()) || hasHideAnnotation(sourcePsi())
+    return hasSuppressDocTag(sourcePsi()) ||
+            hasHideAnnotation(sourcePsi()) ||
+            hasRestrictToAnnotation(sourcePsi())
 }
 
 fun DeclarationDescriptor.sourcePsi() =

--- a/core/src/test/kotlin/model/JavaTest.kt
+++ b/core/src/test/kotlin/model/JavaTest.kt
@@ -170,6 +170,20 @@ public class JavaTest {
         }
     }
 
+    /**
+     * @restrictTo behaves like @hide.  This test is very similar to the [hideAnnotation] test.
+     */
+    @Test fun restrictToAnnotation() {
+        verifyJavaPackageMember("testdata/java/restrictToAnnotation.java") { cls ->
+            assertEquals(1, cls.members(NodeKind.Function).size)
+            assertEquals(1, cls.members(NodeKind.Property).size)
+
+            // The test file contains two classes, one of which is restricted.
+            // The test for @RestrictTo annotation on classes is via verifyJavaPackageMember(),
+            // which will throw an IllegalArgumentException if it detects more than one class.
+        }
+    }
+
     @Test fun annotatedAnnotation() {
         verifyJavaPackageMember("testdata/java/annotatedAnnotation.java") { cls ->
             assertEquals(1, cls.annotations.size)

--- a/core/testdata/java/restrictToAnnotation.java
+++ b/core/testdata/java/restrictToAnnotation.java
@@ -1,0 +1,27 @@
+public class ShownClass {
+
+  static int shownInt;
+
+  /**
+   * @RestrictTo
+   */
+  public static int restrictedInt;
+
+  public static void shownMethod() {
+
+  }
+
+  /**
+   * @RestrictTo
+   */
+  public static void restrictedMethod() {
+
+  }
+}
+
+/**
+ * @RestrictTo
+ */
+public class RestrictedClass {
+
+}


### PR DESCRIPTION
@RestrictTo behaves exactly like the @hide annotation, which excludes
the element from generated documentation.