### PR TITLE
Encoding URL anchors as URIs rather than with the misleading URLEncoder

### DIFF
--- a/core/src/main/kotlin/Formats/DacHtmlFormat.kt
+++ b/core/src/main/kotlin/Formats/DacHtmlFormat.kt
@@ -67,7 +67,7 @@ class DevsiteLayoutHtmlFormatOutputBuilder(
 
     override fun FlowContent.fullMemberDocs(node: DocumentationNode, uriNode: DocumentationNode) {
         a {
-            attributes["name"] = uriNode.signatureForAnchor(logger).urlEncoded()
+            attributes["name"] = uriNode.signatureForAnchor(logger).anchorEncoded()
         }
         div(classes = "api apilevel-${node.apiLevel.name}") {
             attributes["data-version-added"] = node.apiLevel.name

--- a/core/src/main/kotlin/Formats/JavaLayoutHtml/JavaLayoutHtmlFormat.kt
+++ b/core/src/main/kotlin/Formats/JavaLayoutHtml/JavaLayoutHtmlFormat.kt
@@ -8,7 +8,6 @@ import org.jetbrains.dokka.Utilities.lazyBind
 import org.jetbrains.dokka.Utilities.toOptional
 import org.jetbrains.dokka.Utilities.toType
 import java.net.URI
-import java.net.URLEncoder
 import kotlin.reflect.KClass
 
 
@@ -139,8 +138,6 @@ fun DocumentationNode.signatureForAnchor(logger: DokkaLogger): String {
         else -> "Not implemented signatureForAnchor $this".also { logger.warn(it) }
     }
 }
-
-fun String.urlEncoded(): String = URLEncoder.encode(this, "UTF-8")
 
 fun DocumentationNode.classNodeNameWithOuterClass(): String {
     assert(kind in NodeKind.classLike)

--- a/core/src/main/kotlin/Formats/JavaLayoutHtml/JavaLayoutHtmlGenerator.kt
+++ b/core/src/main/kotlin/Formats/JavaLayoutHtml/JavaLayoutHtmlGenerator.kt
@@ -67,7 +67,7 @@ class JavaLayoutHtmlFormatGenerator @Inject constructor(
         }?.resolve(outlineRoot)
     }
 
-    fun URI.resolveInPage(node: DocumentationNode): URI = resolve("#${node.signatureForAnchor(logger).urlEncoded()}")
+    fun URI.resolveInPage(node: DocumentationNode): URI = resolve("#${node.signatureForAnchor(logger).anchorEncoded()}")
 
     fun buildClass(node: DocumentationNode, parentDir: File) {
         val fileForClass = parentDir.resolve(node.classNodeNameWithOuterClass() + ".html")

--- a/core/src/main/kotlin/Formats/JavaLayoutHtml/JavaLayoutHtmlPackageListService.kt
+++ b/core/src/main/kotlin/Formats/JavaLayoutHtml/JavaLayoutHtmlPackageListService.kt
@@ -148,7 +148,7 @@ class JavaLayoutHtmlInboundLinkResolutionService(private val paramMap: Map<Strin
         }
     }
 
-    private fun DeclarationDescriptor.signatureForAnchorUrlEncoded(): String? = signatureForAnchor()?.urlEncoded()
+    private fun DeclarationDescriptor.signatureForAnchorUrlEncoded(): String? = signatureForAnchor()?.anchorEncoded()
 
     override fun getPath(symbol: DeclarationDescriptor) = if (isJavaMode) getJavaPagePath(symbol) else getPagePath(symbol)
 }

--- a/core/src/main/kotlin/Utilities/Html.kt
+++ b/core/src/main/kotlin/Utilities/Html.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.dokka
 
-import java.net.URLEncoder
+import java.net.URI
 
 
 /**
@@ -9,4 +9,10 @@ import java.net.URLEncoder
  */
 fun String.htmlEscape(): String = replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
-fun String.urlEncoded(): String = URLEncoder.encode(this, "UTF-8")
+// A URI consists of several parts (as described in https://docs.oracle.com/javase/7/docs/api/java/net/URI.html ):
+// [scheme:][//authority][path][?query][#fragment]
+//
+// The anchorEnchoded() function encodes the given string to make it a legal value for <fragment>
+fun String.anchorEncoded(): String {
+    return URI(null, null, this).getRawFragment()
+}


### PR DESCRIPTION
Oddly enough, URLEncoder isn't exactly intended for encoding URIs/URLs.
Note that URLEncoder doesn't ask which part of a URI
(the scheme, authority, path, query, or fragment) it is encoding
(each of which have a slightly different set of special characters).

Instead, this encodes URIs via java.net.URI

Bug: 123716922