### PR TITLE
Automate Downloading of Code Samples

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     compile "teamcity:kotlin-ide-common:$bundled_kotlin_compiler_version"
     compile "org.jetbrains:markdown:$markdownVersion"
 
+    implementation "com.squareup.okhttp3:okhttp:4.0.0-RC1"
+
     compile intellijCoreAnalysis()
 
 //    Google version of the library in the libs folder. Fixing 129528660

--- a/core/src/main/kotlin/Utilities/DownloadSamples.kt
+++ b/core/src/main/kotlin/Utilities/DownloadSamples.kt
@@ -44,10 +44,10 @@ object DownloadSamples {
             if (response.isSuccessful) {
 
                 //save .tar.gz file to filepath designated by map
-                var currentFile = File(filepath)
+                val currentFile = File(filepath)
                 currentFile.mkdirs()
 
-                var fos = FileOutputStream("$filepath.tar.gz")
+                val fos = FileOutputStream("$filepath.tar.gz")
                 fos.write(response.body?.bytes())
                 fos.close()
 

--- a/core/src/main/kotlin/Utilities/DownloadSamples.kt
+++ b/core/src/main/kotlin/Utilities/DownloadSamples.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.dokka.Utilities
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+
+object DownloadSamples {
+
+    /** HTTP Client to make requests **/
+    val client = OkHttpClient()
+
+    /**
+     * Function that downloads samples based on the directory structure described in hashmap
+     */
+    fun downloadSamples(): Boolean {
+
+        //loop through each directory of AOSP code in SamplesPathsToURLs.kt
+        filepathsToUrls.forEach { (filepath, url) ->
+
+            //build request using each URL
+            val request = Request.Builder()
+                .url(url)
+                .build()
+
+            val response = client.newCall(request).execute()
+
+            if (response.isSuccessful) {
+
+                //save .tar.gz file to filepath designated by map
+                var currentFile = File(filepath)
+                currentFile.mkdirs()
+
+                var fos = FileOutputStream("$filepath.tar.gz")
+                fos.write(response.body?.bytes())
+                fos.close()
+
+                //Unzip, Untar, and delete compressed file after
+                extractFiles(filepath)
+
+            } else {
+                println("Error Downloading Samples: $response")
+                return false
+            }
+        }
+
+        println("Successfully completed download of samples.")
+        return true
+
+    }
+
+    /**
+     * Execute bash commands to extract file, then delete archive file
+     */
+    private fun extractFiles(pathToFile: String) {
+
+        ProcessBuilder()
+            .command("tar","-zxf", "$pathToFile.tar.gz", "-C", pathToFile)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .start()
+            .waitFor()
+
+        ProcessBuilder()
+            .command("rm", "$pathToFile.tar.gz")
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .start()
+            .waitFor()
+    }
+
+}

--- a/core/src/main/kotlin/Utilities/SamplesPathsToURLs.kt
+++ b/core/src/main/kotlin/Utilities/SamplesPathsToURLs.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.dokka.Utilities
+
+//HashMap of all filepaths to the URLs that should be downloaded to that filepath
+val filepathsToUrls: HashMap<String, String> = hashMapOf(
+    "./samples/development/samples/ApiDemos" to "https://android.googlesource.com/platform/development/+archive/refs/heads/master/samples/ApiDemos.tar.gz",
+    "./samples/development/samples/NotePad" to "https://android.googlesource.com/platform/development/+archive/refs/heads/master/samples/NotePad.tar.gz",
+    "./samples/external/icu/android_icu4j/src/samples/java/android/icu/samples/text" to "https://android.googlesource.com/platform/external/icu/+archive/refs/heads/master/android_icu4j/src/samples/java/android/icu/samples/text.tar.gz",
+    "./samples/frameworks/base/core/java/android/content" to "https://android.googlesource.com/platform/frameworks/base/+archive/refs/heads/master/core/java/android/content.tar.gz",
+    "./samples/frameworks/base/tests/appwidgets/AppWidgetHostTest/src/com/android/tests/appwidgethost" to "https://android.googlesource.com/platform/frameworks/base/+archive/refs/heads/master/tests/appwidgets/AppWidgetHostTest/src/com/android/tests/appwidgethost.tar.gz"
+    )

--- a/runners/cli/src/main/kotlin/cli/main.kt
+++ b/runners/cli/src/main/kotlin/cli/main.kt
@@ -4,6 +4,7 @@ package org.jetbrains.dokka
 import com.sampullara.cli.Args
 import com.sampullara.cli.Argument
 import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
+import org.jetbrains.dokka.Utilities.DownloadSamples
 
 import java.io.File
 import java.net.MalformedURLException
@@ -22,6 +23,9 @@ class DokkaArguments {
 
     @set:Argument(value = "samples", description = "Source root for samples")
     var samples: String = ""
+
+    @set:Argument(value = "useSamplesURL", description = "Download samples from URL into root folder")
+    var useSamplesURL: Boolean = false
 
     @set:Argument(value = "output", description = "Output directory path")
     var outputDir: String = "out/doc/"
@@ -121,6 +125,8 @@ object MainKt {
         }
 
         val classPath = arguments.classpath.split(File.pathSeparatorChar).toList()
+
+        if (arguments.useSamplesURL) DownloadSamples.downloadSamples()
 
         val documentationOptions = DocumentationOptions(
             arguments.outputDir.let { if (it.endsWith('/')) it else it + '/' },


### PR DESCRIPTION
Feature Request that automates downloading of Samples (Collection of code snippets from AOSP) to eliminate the need to manually download and move to dokka root folder. Uses okhttp to create http requests to repos hosted at https://android.googlesource.com/. Then uses the tar and rm command line tools to to extract the downloads and remove unnecessary files. In order to have dokka automatically download the samples, use the -useSamplesURL tag in Run Configurations -> Program Arguments.